### PR TITLE
Enable run without VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In your IoT Central application create a new device based on your new template a
   * Copy the values for "ID scope", "Device ID", and "Primary key". You will use these values in the device sample code.
 
 ## Run the sample code
-Create a ".env" file at the root of your project and add the values you copied above. The file should look like the sample below with your own values. NOTE: the modelId is copied from the */setup/DeviceDcm.json* file.
+Create a ".env" file at the root of your project and add the values you copied above. The file should look like the sample below with your own values. NOTE: the modelId is copied from the */setup/FileUploadDeviceDcm.json* file.
 ```
 scopeId=<YOUR_SCOPE_ID>
 deviceId=<YOUR_DEVICE_ID>
@@ -74,7 +74,7 @@ deviceKey=<YOUR_PRIMARY_KEY>
 modelId=urn:IoTCentral:IotCentralFileUploadDevice:1
 ```
 
-Now you are ready to run the sample. Press F5 to run/debug the sample. In your terminal window you should see that the device is registered and is connected to IoT Central:
+Now you are ready to run the sample. Press F5 to run/debug the sample in VSCode or _npm run start_ in command line otherwise. In your terminal window you should see that the device is registered and is connected to IoT Central:
 ```
 Starting IoT Central device...
  > Machine: ...

--- a/device.ts
+++ b/device.ts
@@ -151,7 +151,7 @@ export class IoTCentralDevice {
 
                 switch (setting) {
                     case SettingFilenameSuffix:
-                        this.log(`Updating setting: ${setting} with value: ${value}`);
+                        this.log(`Updating setting: ${setting} with value: ${JSON.stringify(value)}`);
 
                         // NOTE: validation should be in place for legal folder names
                         patchedProperties[setting] = this.deviceSettings[setting] = value || moment.utc().format('YYYYMMDD-HHmmss');
@@ -204,7 +204,7 @@ export class IoTCentralDevice {
         this.log(`Updating twin properties: ${JSON.stringify(properties, null, 4)}`);
 
         try {
-            await new Promise((resolve, reject) => {
+            await new Promise<void>((resolve, reject) => {
                 this.deviceTwin.properties.reported.update(properties, (error) => {
                     if (error) {
                         return reject(error);

--- a/index.ts
+++ b/index.ts
@@ -1,52 +1,79 @@
 import {
-    type as osType,
-    cpus as osCpus,
-    freemem as osFreeMem,
-    totalmem as osTotalMem
+  type as osType,
+  cpus as osCpus,
+  freemem as osFreeMem,
+  totalmem as osTotalMem
 } from 'os';
 import { IoTCentralDevice } from './device';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+const ENV_PATH = path.join(process.cwd(), '.env');
 
 function log(message: string) {
-    // tslint:disable-next-line:no-console
-    console.log(message);
+  // tslint:disable-next-line:no-console
+  console.log(message);
 }
 
 async function start() {
-    try {
-        log('🚀 Starting IoT Central device...');
-        log(` > Machine: ${osType()}, ${osCpus().length} core, `
-            + `freemem=${(osFreeMem() / 1024 / 1024).toFixed(0)}mb, totalmem=${(osTotalMem() / 1024 / 1024).toFixed(0)}mb`);
+  try {
+    log('🚀 Starting IoT Central device...');
+    log(
+      ` > Machine: ${osType()}, ${osCpus().length} core, ` +
+        `freemem=${(osFreeMem() / 1024 / 1024).toFixed(0)}mb, totalmem=${(
+          osTotalMem() /
+          1024 /
+          1024
+        ).toFixed(0)}mb`
+    );
 
-        const {
-            scopeId,
-            deviceId,
-            deviceKey,
-            modelId
-        } = process.env;
+    let { scopeId, deviceId, deviceKey, modelId } = process.env;
 
-        if (!scopeId || !deviceId || !deviceKey || !modelId) {
-            log('Error - missing required environment variables scopeId, deviceId, deviceKey, modelId');
-            return;
-        }
-
-        const iotDevice = new IoTCentralDevice(log, scopeId, deviceId, deviceKey, modelId);
-
-        log('Starting device registration...');
-        const connectionString = await iotDevice.provisionDeviceClient();
-
-        if (connectionString) {
-            log('Connecting the device...');
-            await iotDevice.connectDeviceClient(connectionString);
-        }
-        else {
-            log(' Failed to obtain connection string for device.');
-        }
+    if (!scopeId || !deviceId || !deviceKey || !modelId) {
+      log(
+        'Error - missing required environment variables scopeId, deviceId, deviceKey, modelId'
+      );
+      log(`Try reading from environment file ${ENV_PATH}`);
+      try {
+        ({ scopeId, deviceId, deviceKey, modelId } = (
+          await fs.readFile(ENV_PATH)
+        )
+          .toString()
+          .split(/\r?\n/)
+          .reduce<{ [x: string]: string }>((obj, evar) => {
+            const line = evar.split('=');
+            obj[line[0]] = line[1];
+            return obj;
+          }, {}));
+      } catch (ex) {
+        log('Error reading environment file');
+        return;
+      }
     }
-    catch (error) {
-        log(`👹 Error starting process: ${error.message}`);
+    log(`Device: ${deviceId}, Scope: ${scopeId}`);
+
+    const iotDevice = new IoTCentralDevice(
+      log,
+      scopeId,
+      deviceId,
+      deviceKey,
+      modelId
+    );
+
+    log('Starting device registration...');
+    const connectionString = await iotDevice.provisionDeviceClient();
+
+    if (connectionString) {
+      log('Connecting the device...');
+      await iotDevice.connectDeviceClient(connectionString);
+    } else {
+      log(' Failed to obtain connection string for device.');
     }
+  } catch (error) {
+    log(`👹 Error starting process: ${error.message}`);
+  }
 }
 
 (async () => {
-    await start();
+  await start();
 })().catch();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "main": "index.js",
     "scripts": {
         "tslint": "node ./node_modules/tslint/bin/tslint -p ./tsconfig.json",
-        "build": "node ./node_modules/typescript/bin/tsc -p ."
+        "build": "node ./node_modules/typescript/bin/tsc -p .",
+        "start": "node dist/index.js"
     },
     "author": "sseiber",
     "license": "MIT",


### PR DESCRIPTION
Current sample instructions expect run through VSCode. If user wants to run the whole sample from command line or with a different IDE, there would be few steps required.
This PR allows use from outside VSCode:

- Add "npm start" script.
- Support of ".env" file.
- Add details in README